### PR TITLE
Add 'GroupExternalAuthNCheck' directive to prevent mod-authz-external from checking whether Authentication has successfully occurred. + Minor Improvements

### DIFF
--- a/mod_authnz_external/INSTALL
+++ b/mod_authnz_external/INSTALL
@@ -555,6 +555,19 @@ instructions to your server configuration.
     Under Apache 2.4 you can control the return code using the
     'AuthzSendForbiddenOnFailure' directive.
 
+    * USING GROUP CHECKING INDEPENDENT OF USER CHECKING:
+
+    Normally, the group authorization process checks that a user was 
+    successfully authenticated by the user authentication module before 
+    actually running the external group checking program.  This may be 
+    undesirable if your goal is to use mod_authz_external on its own as 
+    a group checker, without any user checking. You can use the 
+    following directive in your Apache config to disable the user 
+    authentication check:
+    
+    GroupExternalAuthNCheck Off
+    
+
     * INTERACTIONS WITH OTHER AUTHENTICATORS:
 
     Previous versions of mod_authnz_external had 'GroupExternalAuthoritative'

--- a/mod_authnz_external/mod_authnz_external.c
+++ b/mod_authnz_external/mod_authnz_external.c
@@ -640,7 +640,7 @@ static authz_status externalgroup_check_authorization(request_rec *r,
     char *extname= dir->group_name;
     const char *extpath, *extmethod;
     const char *t, *w;
-    int code;
+    int code = 0;
 
     if (dir->authncheck){
         /* If no authenticated user, pass */
@@ -682,8 +682,8 @@ static authz_status externalgroup_check_authorization(request_rec *r,
 
     ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
 	"Authorization of user %s to access %s failed. "
-	"User not in Required group.",
-    	r->user, r->uri);
+	"User not in Required group. Last result code: %i",
+    	r->user, r->uri, code);
 
     return AUTHZ_DENIED;
 }
@@ -704,7 +704,6 @@ static authz_status externalfilegroup_check_authorization(request_rec *r,
     char *extname= dir->group_name;
     const char *extpath, *extmethod;
     const char *filegroup= NULL;
-    const char *t, *w;
     int code;
 
     if (dir->authncheck){

--- a/mod_authnz_external/mod_authnz_external.c
+++ b/mod_authnz_external/mod_authnz_external.c
@@ -122,6 +122,7 @@ typedef struct
     char *context;		 /* Context string from AuthExternalContext */
     int  groupsatonce;		 /* Check all groups in one call? */
     int  providecache;		 /* Provide auth data to mod_authn_socache? */
+    int  authncheck;		 /* Check for previous authentication? */
 
 } authnz_external_dir_config_rec;
 
@@ -160,6 +161,7 @@ static void *create_authnz_external_dir_config(apr_pool_t *p, char *d)
     dir->context= NULL;		/* no default */
     dir->groupsatonce= 1;	/* default to on */
     dir->providecache= 0;	/* default to off */
+    dir->authncheck= 1;		/* default to on */
     return dir;
 }
 
@@ -358,6 +360,13 @@ static const command_rec authnz_external_cmds[] =
 	(void *)APR_OFFSETOF(authnz_external_dir_config_rec, groupsatonce),
 	OR_AUTHCFG,
 	"Old version of 'GroupExternalManyAtOnce'" ),
+	
+	AP_INIT_FLAG("GroupExternalAuthNCheck",
+	ap_set_flag_slot,
+	(void *)APR_OFFSETOF(authnz_external_dir_config_rec, authncheck),
+	OR_AUTHCFG,
+	"Set to 'off' if group authenticator should skip checking whether "
+			"user is validly authenticated"),
 
     { NULL }
 };
@@ -633,8 +642,13 @@ static authz_status externalgroup_check_authorization(request_rec *r,
     const char *t, *w;
     int code;
 
-    /* If no authenticated user, pass */
-    if ( !user ) return AUTHZ_DENIED_NO_USER;
+    if (dir->authncheck){
+        /* If no authenticated user, pass */
+        if ( !user ) return AUTHZ_DENIED_NO_USER;
+    }else{
+		/* Prevent crash due to missing user */
+		if ( !user ) r->user = "";
+	}
 
     /* If no external authenticator has been configured, pass */
     if ( !extname ) return AUTHZ_DENIED;
@@ -693,8 +707,13 @@ static authz_status externalfilegroup_check_authorization(request_rec *r,
     const char *t, *w;
     int code;
 
-    /* If no authenticated user, pass */
-    if ( !user ) return AUTHZ_DENIED_NO_USER;
+    if (dir->authncheck){
+        /* If no authenticated user, pass */
+        if ( !user ) return AUTHZ_DENIED_NO_USER;
+    }else{
+		/* Prevent crash due to missing user */
+		if ( !user ) r->user = "";
+	}
 
     /* If no external authenticator has been configured, pass */
     if ( !extname ) return AUTHZ_DENIED;

--- a/mod_authnz_external/mod_authnz_external.c
+++ b/mod_authnz_external/mod_authnz_external.c
@@ -366,7 +366,7 @@ static const command_rec authnz_external_cmds[] =
 	(void *)APR_OFFSETOF(authnz_external_dir_config_rec, authncheck),
 	OR_AUTHCFG,
 	"Set to 'off' if group authenticator should skip checking whether "
-			"user is validly authenticated"),
+        "user is validly authenticated"),
 
     { NULL }
 };
@@ -646,9 +646,9 @@ static authz_status externalgroup_check_authorization(request_rec *r,
         /* If no authenticated user, pass */
         if ( !user ) return AUTHZ_DENIED_NO_USER;
     }else{
-		/* Prevent crash due to missing user */
-		if ( !user ) r->user = "";
-	}
+        /* Prevent crash due to missing user */
+        if ( !user ) r->user = "";
+    }
 
     /* If no external authenticator has been configured, pass */
     if ( !extname ) return AUTHZ_DENIED;
@@ -710,9 +710,9 @@ static authz_status externalfilegroup_check_authorization(request_rec *r,
         /* If no authenticated user, pass */
         if ( !user ) return AUTHZ_DENIED_NO_USER;
     }else{
-		/* Prevent crash due to missing user */
-		if ( !user ) r->user = "";
-	}
+        /* Prevent crash due to missing user */
+        if ( !user ) r->user = "";
+    }
 
     /* If no external authenticator has been configured, pass */
     if ( !extname ) return AUTHZ_DENIED;


### PR DESCRIPTION
### This is useful for using mod_authz_external as a generic external authorization mechanism, without needing to use Apache's Authentication module (or triggering mod_authn_basic browser login boxes).
- 'GroupExternalAuthNCheck' is set to 'On' by default for compatibility with all existing configurations.
- When set to 'Off', externalgroup_check_authorization() and externalfilegroup_check_authorization() do not perform the Authentication check.
  - Also, if 'user' is not set, we now set it to the empty string to prevent a segfault in the Apache process (from trying to print it to stderr).
- 't' and 'w' are never used in externalfilegroup_check_authorization(), so removed.
- externalgroup_check_authorization() now logs the last failing result code along with the 'User not in Required group.' message.
  - 'code' is initialized to 0 to prevent a compiler warning.