### PR TITLE
 Fix launch of external processes on Windows - add %SystemRoot%

### DIFF
--- a/mod_authnz_external/INSTALL
+++ b/mod_authnz_external/INSTALL
@@ -303,7 +303,7 @@ instructions to your server configuration.
 	    typically used as config file path.  The ":" is required even if
 	    the <data> is an empty string.
 
-	In the old-style syntax, the path declaration should always preced
+	In the old-style syntax, the path declaration should always precede
 	the method declaration, and the method declaration can be omitted if
 	you want the default.
 

--- a/mod_authnz_external/mod_authnz_external.c
+++ b/mod_authnz_external/mod_authnz_external.c
@@ -409,7 +409,7 @@ static int exec_external(const char *extpath, const char *extmethod,
     apr_procattr_t *procattr;
     apr_proc_t proc;
     apr_status_t rc= APR_SUCCESS;
-    char *child_env[12];
+    char *child_env[13];
     char *child_arg[MAX_ARG+2];
     const char *t;
     int i, status= -4;
@@ -470,6 +470,10 @@ static int exec_external(const char *extpath, const char *extmethod,
 #ifdef ENV_COOKIE
 	if ((cookie= apr_table_get(r->headers_in, "Cookie")) != NULL)
 	    child_env[i++]= apr_pstrcat(p, ENV_COOKIE"=", cookie, NULL);
+#endif
+		
+#ifdef _WINDOWS
+    child_env[i++]= apr_pstrcat(r->pool, "SystemRoot=", getenv("SystemRoot"), NULL);
 #endif
 	/* NOTE:  If you add environment variables,
 	 *   remember to increase the size of the child_env[] array */


### PR DESCRIPTION
When compiling mod_auth_external on Windows, the SystemRoot environment variable was not set.
%SystemRoot% is supposed to point to the directory where Windows is installed (e.g. C:\WINDOWS or D:\OS\WINNT or whatever you set it to when you installed Windows)

_Seemingly random things stop working_ when the SystemRoot environment variable is missing:

- standard Windows file open dialog
- ping command's DNS resolution
- external php script's mysqli remote database access
- etc.


p.s. also the random spelling fix from earlier is in here too for convenience...