### PR TITLE
mod_authz_unixgroup: Use getgrouplist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,24 +17,29 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     
-    - name: install apache (ubuntu)
+    - name: install apache and libbsd (ubuntu)
       if: runner.os == 'Linux'
-      run: sudo apt-get install apache2 apache2-dev
-          
-    - name: install apache (macos)
+      run: sudo apt-get install apache2 apache2-dev libbsd-dev
+    
+    - name: install apache and libbsd (macos)
       if: runner.os == 'macOS'
-      run: brew install httpd
-      
+      run: |
+        # use latest master, not stable (until libbsd mac version is in stable)
+        brew developer on
+        # grab master version of libbsd with mac support
+        brew update
+        brew install httpd libbsd
+    
     - name: make mod_authnz_external (POSIX-GCC)
       if: runner.os != 'Windows'
       run: make
       working-directory: ./mod_authnz_external
-
+    
     - name: make mod_authz_unixgroup (POSIX-GCC)
       if: runner.os != 'Windows'
       run: make
       working-directory: ./mod_authz_unixgroup
-      
+    
     - name: nmake (MSVC)
       if: runner.os == 'Windows'
       run: |

--- a/mod_authz_unixgroup/CONTRIBUTORS
+++ b/mod_authz_unixgroup/CONTRIBUTORS
@@ -12,3 +12,4 @@ mod_authz_unixgroup is based on code from the following sources:
 	David Homborg
 	klemens/ka7
 	Micah Andersen/Baptist International Missions, Inc. (micah@bimi.org)
+	Joakim Tjernlund/joakim-tjernlund (joakim.tjernlund@infinera.com)

--- a/mod_authz_unixgroup/INSTALL
+++ b/mod_authz_unixgroup/INSTALL
@@ -42,12 +42,17 @@ Step 2:
 	Compile the module using the following command in the
 	mod_authz_unixgroup distribution directory:
 
-		apxs -c mod_authz_unixgroup.c
+		apxs -c mod_authz_unixgroup.c -lbsd
 
-	'Apxs' is the Apache extension tool.  It is part of the standard
-	Apache installation.  If you don't have it, then your Apache server
-	is probably not set up for handling dynamically loaded modules.
-	This should create a file named 'mod_authz_unixgroup.so'.
+	* Build using just POSIX group interfaces:
+	  	apxs -c mod_authz_unixgroup.c -DUSE_POSIX_GRP
+	  NOTE that some group providers (e.g sssd) can optionally omit gr_mem
+	  in struct grp which will break POSIX API (in addition to being slower)
+
+	* 'Apxs' is the Apache extension tool.  It is part of the standard
+	  Apache installation.  If you don't have it, then your Apache server
+	  is probably not set up for handling dynamically loaded modules.
+	  This should create a file named 'mod_authz_unixgroup.so'.
 
 Step 3:
 	Install the module.  Apxs can do this for you too.  Do the following

--- a/mod_authz_unixgroup/Makefile
+++ b/mod_authz_unixgroup/Makefile
@@ -2,6 +2,10 @@
 #APXS=apxs2
 APXS=apxs
 
+ifneq ($(OS),Windows_NT)
+	OS := $(shell uname -s)
+endif
+
 TAR= README INSTALL NOTICE CHANGES CONTRIBUTORS LICENSE \
 	mod_authz_unixgroup.c Makefile Makefile.win
 
@@ -14,13 +18,17 @@ install: mod_authz_unixgroup.la
 build: mod_authz_unixgroup.la
 
 mod_authz_unixgroup.la: mod_authz_unixgroup.c
-	$(APXS) -c mod_authz_unixgroup.c
+	$(info REMINDER: This project requires libbsd and associated headers to compile and run. Please install any necessary development packages for your platform if you have not already. macOS users should install libbsd via homebrew.)
+ifeq ($(OS),Darwin)
+		$(APXS) -I/opt/homebrew/opt/libbsd/include -c mod_authz_unixgroup.c 
+else
+		$(APXS) -c mod_authz_unixgroup.c -lbsd
+endif
 
 clean:
 	rm -rf mod_authz_unixgroup.so mod_authz_unixgroup.o \
 	    mod_authz_unixgroup.la mod_authz_unixgroup.slo \
 	    mod_authz_unixgroup.lo .libs
-	-ls -a .*.swp
 
 tar: mod_authz_unixgroup.tar
 


### PR DESCRIPTION
Some services, like sssd, can optimize away grp->gr_mem which makes this module fail group lookup.

Use getgrouplist(3) instead and gid_from_group(3bsd) which uses libbsd, link with -lbsd.
This avoids the problematic getgrgid()/getgrnam() functions.

This replaces https://github.com/phokz/mod-auth-external/pull/54