### PR TITLE
No Authenticated User Responds With 401

### DIFF
--- a/mod_authnz_external/mod_authnz_external.c
+++ b/mod_authnz_external/mod_authnz_external.c
@@ -674,7 +674,7 @@ static authz_status externalgroup_check_authorization(request_rec *r,
 		r->user, r->uri, code);
 
         // Revisit whether there was an authenticated user so that we can flag Apache appropriately
-        if (user == "") return AUTHZ_DENIED_NO_USER;
+        if (r->user == "") return AUTHZ_DENIED_NO_USER;
 
 	return AUTHZ_DENIED;
 }

--- a/mod_authnz_external/mod_authnz_external.c
+++ b/mod_authnz_external/mod_authnz_external.c
@@ -673,6 +673,9 @@ static authz_status externalgroup_check_authorization(request_rec *r,
 		"User not in Required group. Last result code: %i",
 		r->user, r->uri, code);
 
+        // Revisit whether there was an authenticated user so that we can flag Apache appropriately
+        if (user == "") return AUTHZ_DENIED_NO_USER;
+
 	return AUTHZ_DENIED;
 }
 


### PR DESCRIPTION
This allows the module to be used for anonymous Authz (`GroupExternalAuthnCheck Off`) and flag to Apache so that it can negotiate the Authn upon failure.

Proposed solution for #66 
Resolves #66 