### PR TITLE
Configure a code for Authenticators to indicate AUTH_USER_NOT_FOUND

### DIFF
--- a/mod_authnz_external/CONTRIBUTORS
+++ b/mod_authnz_external/CONTRIBUTORS
@@ -50,3 +50,5 @@ mod_authnz_external is based on code from the following sources:
 	klemens/ka7
 	Josef Liska		(josef.liska@virtualmaster.com)
 	Micah Andersen/Baptist International Missions, Inc. (micah@bimi.org)
+	Matt Johnston/mkj	(matt@ucc.asn.au)
+

--- a/mod_authnz_external/CONTRIBUTORS
+++ b/mod_authnz_external/CONTRIBUTORS
@@ -51,4 +51,5 @@ mod_authnz_external is based on code from the following sources:
 	Josef Liska		(josef.liska@virtualmaster.com)
 	Micah Andersen/Baptist International Missions, Inc. (micah@bimi.org)
 	Matt Johnston/mkj	(matt@ucc.asn.au)
+	Matthew Turner/carrvo	(carrvo@gmail.com)
 

--- a/mod_authnz_external/INSTALL
+++ b/mod_authnz_external/INSTALL
@@ -574,6 +574,11 @@ instructions to your server configuration.
     directive. In Apache 2.4, the notion of authoritativeness is
     thankfully almost entirely gone, so this directive is too.
     
+    If you want the ability to specify a return code for your authenticator
+    to indicate that it could not find a user:
+    
+    AuthnUserNotFoundCode <code>
+    
     * OLD DIRECTIVES
 
     Some of the directives mentioned above used to have different names.

--- a/mod_authnz_external/INSTALL
+++ b/mod_authnz_external/INSTALL
@@ -574,11 +574,16 @@ instructions to your server configuration.
     directive. In Apache 2.4, the notion of authoritativeness is
     thankfully almost entirely gone, so this directive is too.
     
-    If you want the ability to specify a return code for your authenticator
+    If you want to enable your authenticator to gracefully hand off authority to
+    the next apache authentication module when your authenticator cannot locate
+    the submitted user, you can specify a return code for your authenticator
     to indicate that it could not find a user:
     
     AuthnUserNotFoundCode <code>
     
+    Note that a configuration of 0 will effectively disable this feature
+    (0 always indicates authentication success).
+
     * OLD DIRECTIVES
 
     Some of the directives mentioned above used to have different names.

--- a/mod_authnz_external/mod_authnz_external.c
+++ b/mod_authnz_external/mod_authnz_external.c
@@ -824,10 +824,12 @@ static authn_status authn_external_check_password(request_rec *r,
 			return AUTH_GRANTED;
 		}
 
-		/* Nonexistant login or (for some configurations) incorrect password
-		 * Handle this differently so that unknown users can be passed to the next
-		 * Apache AuthBasicProvider
-		 * Note that a configuration of 0, this will always be true and thus ignored */
+		/* Determine what the return code indicates:
+		 *   - non-existent user in this authenticator (configured code)
+		 *     and gracefully pass authority on to the next external authenticator
+		 *   - incorrect password or other failure (any other code)
+		 * Note that a configuration of 0 will effectively disable this feature
+		 * because it will succeed in the previous step (authentication success) */
 		if (code != dir->authn_no_user_code)
 		{
 			all_not_found = 0;
@@ -840,6 +842,9 @@ static authn_status authn_external_check_password(request_rec *r,
 			extname, extpath, code, r->user);
 	}
 
+        /* If all external authenticators return with non-existent user,
+         * we return AUTH_USER_NOT_FOUND so that we can gracefully
+         * pass authority to the next Apache AuthBasicProvider */
 	if (all_not_found) {
 		return AUTH_USER_NOT_FOUND;
 	}

--- a/mod_authnz_external/mod_authnz_external.c
+++ b/mod_authnz_external/mod_authnz_external.c
@@ -763,7 +763,7 @@ void mock_turtle_cache(request_rec *r, const char *plainpw)
 
 
 /* Password checker for basic authentication - given a login/password,
- * check if it is valid.  Returns one of AUTH_DENIED, AUTH_GRANTED, 
+ * check if it is valid.  Returns one of AUTH_DENIED, AUTH_GRANTED,
  * AUTH_USER_NOT_FOUND, or AUTH_GENERAL_ERROR. */
 
 static authn_status authn_external_check_password(request_rec *r,
@@ -815,7 +815,7 @@ static authn_status authn_external_check_password(request_rec *r,
 			return AUTH_GRANTED;
 		}
 
-		/* code 1 is 
+		/* code 1 is
 		 * STATUS_UNKNOWN
 		 * Nonexistant login or (for some configurations) incorrect password
 		 * Handle this differently so that unknown users can be passed to the next

--- a/mod_authnz_external/mod_authnz_external.c
+++ b/mod_authnz_external/mod_authnz_external.c
@@ -81,6 +81,7 @@ typedef struct
 	char *context;					/* Context string from AuthExternalContext */
 	int  groupsatonce;				/* Check all groups in one call? */
 	int  providecache;				/* Provide auth data to mod_authn_socache? */
+	int  authn_no_user_code;			/* External code to use for no user (HTTP 401) */
 	int  authncheck;				/* Check for previous authentication? */
 
 } authnz_external_dir_config_rec;
@@ -120,6 +121,7 @@ static void *create_authnz_external_dir_config(apr_pool_t *p, char *d)
 	dir->context = NULL;		/* no default */
 	dir->groupsatonce = 1;		/* default to on */
 	dir->providecache = 0;		/* default to off */
+	dir->authn_no_user_code = 0;	/* default to 0 to ignore */
 	dir->authncheck = 1;		/* default to on */
 	return dir;
 }
@@ -320,6 +322,13 @@ static const command_rec authnz_external_cmds[] =
 	(void *)APR_OFFSETOF(authnz_external_dir_config_rec, groupsatonce),
 	OR_AUTHCFG,
 	"Old version of 'GroupExternalManyAtOnce'"),
+
+	AP_INIT_TAKE1("AuthnUserNotFoundCode",
+	ap_set_int_slot,
+	(void *)APR_OFFSETOF(authnz_external_dir_config_rec, authn_no_user_code),
+	OR_AUTHCFG,
+	"Set to a return code that the authenticator uses to indicate that the "
+		"user is not found (respond with HTTP 401). Set to 0 to ignore."),
 
 	AP_INIT_FLAG("GroupExternalAuthNCheck",
 	ap_set_flag_slot,
@@ -815,12 +824,11 @@ static authn_status authn_external_check_password(request_rec *r,
 			return AUTH_GRANTED;
 		}
 
-		/* code 1 is
-		 * STATUS_UNKNOWN
-		 * Nonexistant login or (for some configurations) incorrect password
+		/* Nonexistant login or (for some configurations) incorrect password
 		 * Handle this differently so that unknown users can be passed to the next
-		 * Apache AuthBasicProvider */
-		if (code != 1)
+		 * Apache AuthBasicProvider
+		 * Note that a configuration of 0, this will always be true and thus ignored */
+		if (code != dir->authn_no_user_code)
 		{
 			all_not_found = 0;
 		}

--- a/mod_authnz_external/mod_authnz_external.c
+++ b/mod_authnz_external/mod_authnz_external.c
@@ -81,7 +81,9 @@ typedef struct
 	char *context;					/* Context string from AuthExternalContext */
 	int  groupsatonce;				/* Check all groups in one call? */
 	int  providecache;				/* Provide auth data to mod_authn_socache? */
-	int  authn_no_user_code;			/* External code to use for no user (HTTP 401) */
+	int  authn_user_not_found_code;			/* External code to use for
+              user not found in this authn module and pass authority on to the next module
+              (if no subsequent module finds a user then the final result will be HTTP 401) */
 	int  authncheck;				/* Check for previous authentication? */
 
 } authnz_external_dir_config_rec;
@@ -117,12 +119,12 @@ static void *create_authnz_external_dir_config(apr_pool_t *p, char *d)
 		apr_palloc(p, sizeof(authnz_external_dir_config_rec));
 
 	dir->auth_name = apr_array_make(p, 2, sizeof(const char *)); /* no default */
-	dir->group_name = NULL;		/* no default */
-	dir->context = NULL;		/* no default */
-	dir->groupsatonce = 1;		/* default to on */
-	dir->providecache = 0;		/* default to off */
-	dir->authn_no_user_code = 0;	/* default to 0 to ignore */
-	dir->authncheck = 1;		/* default to on */
+	dir->group_name = NULL;		        /* no default */
+	dir->context = NULL;		        /* no default */
+	dir->groupsatonce = 1;		        /* default to on */
+	dir->providecache = 0;		        /* default to off */
+	dir->authn_user_not_found_code = 0;	/* default to 0 to ignore */
+	dir->authncheck = 1;		        /* default to on */
 	return dir;
 }
 
@@ -325,10 +327,12 @@ static const command_rec authnz_external_cmds[] =
 
 	AP_INIT_TAKE1("AuthnUserNotFoundCode",
 	ap_set_int_slot,
-	(void *)APR_OFFSETOF(authnz_external_dir_config_rec, authn_no_user_code),
+	(void *)APR_OFFSETOF(authnz_external_dir_config_rec, authn_user_not_found_code),
 	OR_AUTHCFG,
 	"Set to a return code that the authenticator uses to indicate that the "
-		"user is not found (respond with HTTP 401). Set to 0 to ignore."),
+		"user is not found in this module, and to pass authority on "
+		"to the next module (if no subsequent module finds a user then "
+		"the final respond will be HTTP 401). Set to 0 to disable."),
 
 	AP_INIT_FLAG("GroupExternalAuthNCheck",
 	ap_set_flag_slot,
@@ -830,7 +834,7 @@ static authn_status authn_external_check_password(request_rec *r,
 		 *   - incorrect password or other failure (any other code)
 		 * Note that a configuration of 0 will effectively disable this feature
 		 * because it will succeed in the previous step (authentication success) */
-		if (code != dir->authn_no_user_code)
+		if (code != dir->authn_user_not_found_code)
 		{
 			all_not_found = 0;
 		}


### PR DESCRIPTION
Resolves #40 

Add AuthnUserNotFoundCode directive

Keeps the existing behaviour (no special return codes) as the default, but allow the user to define a particular return code (new directive) to mean the user does not exist.